### PR TITLE
Add deprecated "onAttach()" to avoid compatibility in API level < 23.

### DIFF
--- a/app/src/main/java/de/tobiasbielefeld/solitaire/classes/CustomPreferenceFragment.java
+++ b/app/src/main/java/de/tobiasbielefeld/solitaire/classes/CustomPreferenceFragment.java
@@ -1,6 +1,8 @@
 package de.tobiasbielefeld.solitaire.classes;
 
+import android.app.Activity;
 import android.content.Context;
+import android.os.Build;
 import android.preference.PreferenceFragment;
 
 import static de.tobiasbielefeld.solitaire.SharedData.reinitializeData;
@@ -16,5 +18,13 @@ public class CustomPreferenceFragment extends PreferenceFragment {
     public void onAttach(Context context) {
         reinitializeData(context);
         super.onAttach(context);
+    }
+
+    @Override
+    public void onAttach(Activity activity){
+        if(Build.VERSION.SDK_INT < Build.VERSION_CODES.M){
+            reinitializeData(activity);
+        }
+        super.onAttach(activity);
     }
 }


### PR DESCRIPTION
Hi,

I notice that you override callback function `onAttach(Context)` in class [`CustomPreferenceFragment`](https://github.com/TobiasBielefeld/Simple-Solitaire/blob/a761ecb0ca3df9dea1b5bb6f8bea7e50f51a2ab1/app/src/main/java/de/tobiasbielefeld/solitaire/classes/CustomPreferenceFragment.java). For your reference, `onAttach(Context)` was added in API level 23, which means it does not execute in API level < 23 (see this [link](https://stackoverflow.com/questions/32083053/android-fragment-onattach-deprecated)). 

To test this issue, when `CustomPreferenceFragment` starts, function `reinitializeData(context)` written in `onAttach(Context)` runs normally in Android 6.0, but this function does not execute in Android 5.1 or earlier devices, meaning that if the app got killed within the `PreferenceFragment` and restarted, the data will not be reinitialized.

This pull request fixes this issue, hope the information is helpful for you.

Thanks.